### PR TITLE
work around timezone issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "isa-calculator",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isa-calculator",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "engines": {
     "node": "8.2"
   },

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -12,12 +12,19 @@ import Switch from 'react-toolbox/lib/switch/Switch'
 
 import {
   formatDate,
-  momentDayOnly,
 } from '@learnersguild/guild-dates'
 
 import {updateForm} from '../store/form'
 
 import cardStyle from './cardStyle'
+
+// react-toolbox's DatePicker assumes _local_ timezone, but guild-dates assumes
+// UTC, so we need to do this conversion to make things behave properly
+const dayOnlyDate = str => {
+  const d = new Date(str)
+  d.setMinutes(d.getTimezoneOffset())
+  return d
+}
 
 class Form extends Component {
   render() {
@@ -30,8 +37,8 @@ class Form extends Component {
       onUpdate,
     } = this.props
 
-    const startDate = momentDayOnly(startDateStr)
-    const exitDate = momentDayOnly(exitDateStr)
+    const startDate = dayOnlyDate(startDateStr)
+    const exitDate = dayOnlyDate(exitDateStr)
 
     const handleUpdate = name => value => {
       onUpdate({
@@ -53,7 +60,7 @@ class Form extends Component {
             label="Start Date"
             onChange={handleUpdate('startDate')}
             inputFormat={formatDate}
-            value={startDate.toDate()}
+            value={startDate}
             required
           />
           <DatePicker
@@ -61,7 +68,7 @@ class Form extends Component {
             label="Exit Date"
             onChange={handleUpdate('exitDate')}
             inputFormat={formatDate}
-            value={exitDate.toDate()}
+            value={exitDate}
             required
           />
           <Input

--- a/src/store/form.js
+++ b/src/store/form.js
@@ -10,9 +10,12 @@ import {
 
 const defaultStartDate = nextStartDate()
 
+// server and browser timezones might differ, so we'll be safe by serializing to date-only strings
+const dateOnlyString = date => momentDayOnly(date).format('YYYY-MM-DD')
+
 export const defaultFormInputs = {
-  startDate: momentDayOnly(defaultStartDate).format('YYYY-MM-DD'),
-  exitDate: momentDayOnly(expectedExitDate(defaultStartDate)).format('YYYY-MM-DD'),
+  startDate: dateOnlyString(defaultStartDate),
+  exitDate: dateOnlyString(expectedExitDate(defaultStartDate)),
   stipendAmount: LIVING_FUND_STIPEND_AMOUNT,
   isTakingLaptopStipend: true,
   expectedAnnualSalary: 90000,
@@ -42,8 +45,8 @@ export const reducer = (state = initialState, action) => {
     case actionTypes.UPDATE_FORM:
       return {
         ...state,
-        startDate: momentDayOnly(startDate).toISOString(),
-        exitDate: momentDayOnly(exitDate).toISOString(),
+        startDate: dateOnlyString(startDate),
+        exitDate: dateOnlyString(exitDate),
         stipendAmount: Number(stipendAmount),
         isTakingLaptopStipend,
         expectedAnnualSalary: Number(expectedAnnualSalary),


### PR DESCRIPTION
Fixes #17.

- use date-only strings in the reducer
- shift from UTC to local timezone in the component